### PR TITLE
Remove Semigroup (Stream a); it's not associative.

### DIFF
--- a/Data/Stream/Infinite.hs
+++ b/Data/Stream/Infinite.hs
@@ -185,9 +185,6 @@ instance Monad Stream where
 interleave :: Stream a -> Stream a -> Stream a
 interleave ~(x :> xs) ys = x :> interleave ys xs
 
-instance Semigroup (Stream a) where
-  (<>) = interleave
-
 -- | The 'inits' function takes a stream @xs@ and returns all the
 -- finite prefixes of @xs@.
 --

--- a/streams.cabal
+++ b/streams.cabal
@@ -34,8 +34,7 @@ description:
   * "Data.Stream.Infinite" provides a coinductive infinite anti-causal stream. The 'Comonad' provides access to the tail of the
     stream and the 'Applicative' zips streams together. Unlike 'Future', infinite stream form a 'Monad'. The monad diagonalizes
     the 'Stream', which is consistent with the behavior of the 'Applicative', and the view of a 'Stream' as a isomorphic to the reader
-    monad from the natural numbers. Being infinite in length, there is no 'Alternative' instance, but instead the 'FunctorAlt'
-    instance provides access to the 'Semigroup' of interleaving streams.
+    monad from the natural numbers. Being infinite in length, there is no 'Alternative' instance.
   .
   > data Stream a = a :< Stream a
   .


### PR DESCRIPTION
``` haskell
*S11> take 10 $ repeat 1 <> (repeat 2 <> repeat 3)
[1,2,1,3,1,2,1,3,1,2]
*S11> take 10 $ (repeat 1 <> repeat 2) <> repeat 3
[1,3,2,3,1,3,2,3,1,3]
```

Given

``` haskell
module S11 where

import Prelude hiding (repeat, take)
import Data.Stream.Infinite
import Data.Semigroup
```
