### PR TITLE
Bump comonad upper version bounds

### DIFF
--- a/streams.cabal
+++ b/streams.cabal
@@ -70,7 +70,7 @@ library
   build-depends:
     base          >= 4       && < 5,
     adjunctions   >= 4.0.1   && < 5,
-    comonad       >= 4       && < 5,
+    comonad       >= 4       && < 6,
     distributive  >= 0.2.1   && < 1,
     semigroupoids >= 4       && < 6,
     semigroups    >= 0.8.3.1 && < 1


### PR DESCRIPTION
I had trouble building the examples from [`zippers`](https://github.com/ekmett/zippers) for this reason.