### PR TITLE
Add Data.Stream.Infinite.head

### DIFF
--- a/src/Data/Stream/Infinite.hs
+++ b/src/Data/Stream/Infinite.hs
@@ -119,6 +119,9 @@ instance Representable Stream where
     | n > 0     = xs !! (n - 1)
     | otherwise = error "Stream.!! negative argument"
 
+-- | Extract the first element of the stream.
+head :: Stream a -> a
+head (x :> _) = x
 
 -- | Extract the sequence following the head of the stream.
 tail :: Stream a -> Stream a


### PR DESCRIPTION
Why not? Given this module will usually be imported qualified due to Prelude clashes, and `Stream.head` is a lot prettier than `(Stream.!! 0)`