### PR TITLE
Depend on semigroups only on GHC < 8.0

### DIFF
--- a/streams.cabal
+++ b/streams.cabal
@@ -81,8 +81,11 @@ library
     boring        >= 0.2     && < 0.3,
     comonad       >= 4       && < 6,
     distributive  >= 0.2.1   && < 1,
-    semigroupoids >= 4       && < 6,
-    semigroups    >= 0.8.3.1 && < 1
+    semigroupoids >= 4       && < 6
+
+  if impl(ghc < 8.0)
+    build-depends:
+      semigroups  >= 0.8.3.1 && < 1
 
   default-extensions: CPP
   if impl(ghc)


### PR DESCRIPTION
It is not needed on newer GHC.